### PR TITLE
Disable internal SMTP server by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -207,12 +207,12 @@ user:
   databaseUsername: admin
   databasePassword: 7layer
   # If setupInternalSMTP is false, you should provide the creds and cert for your external smtp
-  setupInternalSMTP: true
-  smtpHost: smtp
-  smtpPassword: supersecret
-  smtpPort: 25
-  smtpRequireSSL: true
-  smtpUsername: superuser
+  setupInternalSMTP: false
+  smtpHost: notinstalled
+  smtpPassword: notinstalled
+  smtpPort: notinstalled
+  smtpRequireSSL: false
+  smtpUsername: notinstalled
   hostnameWhitelist:
   defaultTenantId: apim
   papiUsername: papi


### PR DESCRIPTION
Port 25 is disabled by public cloud providers by default which makes this the smtp-server a problematic service for us to maintain. We will continue to support the Postfix container but disabled by default.

We will promote the usage of an existing corporate SMTP server or a cloud vendor solution for Kubernetes deployments.