### PR TITLE
Removing external-tenant-host from Helm charts

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -16,10 +16,6 @@ sso url: {{ include "pssg-sso-host" . }}
 analytics url: {{ include "analytics-host" . }}
 broker url: {{ include "broker-host" . }}
 
-{{- if .Values.user.externalTenant }}
-external tenant url: {{ include "external-tenant-host" . }}
-{{- end }}
-
 If this domain is not in your DNS records please add the a record in your
 hosts file to point this domain to any of your kubernetes worker nodes.
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -434,17 +434,6 @@ Generate default tenant endpoint based on configurations
 {{- end -}}
 
 {{/*
-Generate external tenant endpoint based on configurations
-*/}}
-{{- define "external-tenant-host" -}}
-    {{- if .Values.user.legacyHostnames }}
-        {{- printf "%s.%s" .Values.user.externalTenant .Values.user.domain -}}
-    {{- else }}
-        {{- printf "%s-%s.%s" .Values.user.externalTenant .Values.user.kubeNamespace .Values.user.domain -}}
-    {{- end }}
-{{- end -}}
-
-{{/*
 Get "database-port" based on databaseType value
 
 Override logic:

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -53,12 +53,4 @@ spec:
       - backend:
           serviceName: apim
           servicePort: {{ printf "%s-broker" .Values.user.defaultTenantId | quote }}
-  {{- if .Values.user.externalTenant }}
-  - host: {{ include "external-tenant-host" . | quote }}
-    http:
-      paths:
-      - backend:
-          serviceName: dispatcher
-          servicePort: portal-https
-  {{- end -}}
 {{- end }}

--- a/templates/route.yml
+++ b/templates/route.yml
@@ -8,9 +8,6 @@ metadata:
     router: default
 spec:
   host: {{ include "default-tenant-host" . | quote }}
-  {{- if .Values.user.externalTenant }}
-  host: {{ include "external-tenant-host" . | quote }}
-  {{- end }}
   port:
     targetPort: portal-https
   tls:

--- a/values.yaml
+++ b/values.yaml
@@ -195,8 +195,6 @@ user:
   legacyDatabaseNames: false
   domain: example.com
   # the subdomain you would like to use for your external tenant. By providing a value, an ingress rule will be created for accessing
-  # an external tenant
-  externalTenant:
   analyticsEnabled: true
   ssoDebug: false
   enrollNotificationEmail: noreply@mail.example.com


### PR DESCRIPTION
- External tenants should be created following instructions provided in the [Create a New Tenant Wiki page](https://github.com/CAAPIM/portal-helm-charts/wiki/Create-a-New-Tenant)

Reasons for removal:
- Database entries cannot be automatically created making this incomplete
- This only supports one external tenant in a system that supports multiple external tenant