### PR TITLE
change papi port from 9443 to 443 (assume routes for 443 in place)

### DIFF
--- a/templates/apim-config.yaml
+++ b/templates/apim-config.yaml
@@ -14,7 +14,7 @@ data:
   DSSG_SSL_KEY_PASS: {{ required "Please fill in dssgKeyPass in values.yaml" .Values.secrets.dssgKeyPass | quote }}
   NSS_SDB_USE_CACHE: "no"
   OTK_DATABASE_NAME: {{ include "otk-db-name" . | quote }}
-  OTK_PORT: "9443"
+  OTK_PORT: "443"
   PAPI_PASSWORD: {{ .Values.user.papiPassword | quote }}
   PAPI_USERNAME: {{ .Values.user.papiUsername | quote }}
   PORTAL_SUBDOMAIN: {{ required "Please fill in domain in values.yaml" .Values.user.domain | quote }}
@@ -36,7 +36,7 @@ data:
   SSG_USERNAME: admin
   TENANT_ID: {{ include "default-tenant-id" . | quote }}
   TSSG_PUBLIC_HOST: {{ include "tssg-public-host" . | quote }}
-  TSSG_PUBLIC_PORT: "9443"
+  TSSG_PUBLIC_PORT: "443"
 kind: ConfigMap
 metadata:
   labels:

--- a/templates/authenticator-service.yml
+++ b/templates/authenticator-service.yml
@@ -10,7 +10,7 @@ spec:
   ports:
     - port: 9081
       targetPort: 9081
-      name: authenticator-http
+      name: auth-http
   selector:
     name: authenticator
   type: ClusterIP

--- a/templates/tps-config.yaml
+++ b/templates/tps-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   APIM_GATEWAY_HOSTNAME: {{ include "tssg-public-host" . | quote }}
-  APIM_GATEWAY_PORT: "9443"
+  APIM_GATEWAY_PORT: "443"
   APIM_GATEWAY_TENANTID:  {{ include "default-tenant-id" . | quote }}
   APIM_PORTAL_SUBDOMAIN: {{ required "Please fill in domain in values.yaml" .Values.user.domain }}
   BUSINESS_REPORTS_ENABLED: "false"
@@ -15,7 +15,7 @@ data:
   GATEWAY_USERNAME: admin
   JAVA_OPTS: -Xms512m -Xmx512m
   NSS_SDB_USE_CACHE: "no"
-  OTK_PORT: "9443"
+  OTK_PORT: "443"
   PAPI_USERNAME: {{ .Values.user.papiUsername | quote }}
   PORTAL_VERSION: {{ .Chart.AppVersion }}
   PORTAL_DATABASE_NAME: {{ include "portal-db-name" . | quote }}


### PR DESCRIPTION
note: the existing route for papi hostname goes to apim-https, which then routes to ingress service port 8443. it is assumed in app code the designated api then further routes to 9443
for https://github.com/CAAPIM/portal-helm-charts/issues/20