### PR TITLE
Release 4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 files/License.gz
+files/*.crt
+files/*.key
+files/*.p12
+files/*.pem

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ API Portal supports a Kubernetes Private Cloud deployment using preconfigured Po
 ## Wiki
 There's a wealth of instructional and reference information available for setting up API Portal on Kubernetes. See what's available from the [Wiki](https://github.com/CAAPIM/portal-helm-charts/wiki).
 
-## How You Can Contribute
-Contributions are welcome and much appreciated. To learn more, see the Contribution Guidelines.
-
 ## License
 Copyright (c) 2019 CA, A Broadcom Company. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ There's a wealth of instructional and reference information available for settin
 ## License
 Copyright (c) 2019 CA, A Broadcom Company. All rights reserved.
 
-This software may be modified and distributed under the terms of the MIT license. See the LICENSE file for details.
+This software may be modified and distributed under the terms of the MIT license. See the [LICENSE](https://github.com/CAAPIM/portal-helm-charts/blob/master/LICENSE) file for details.

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -8,7 +8,17 @@ To learn more about the release, try:
   $ helm get {{ .Release.Name }}
 
 After the all pods are successfully running you can access the portal at:
-{{ printf "%s.%s" .Values.user.defaultTenantId .Values.user.domain }}
+default tenant url: {{ include "default-tenant-host" . }}
+papi url: {{ include "tssg-public-host" . }}
+enroll url: {{ include "pssg-enroll-host" . }}
+sync url: {{ include "pssg-sync-host" . }}
+sso url: {{ include "pssg-sso-host" . }}
+analytics url: {{ include "analytics-host" . }}
+broker url: {{ include "broker-host" . }}
+
+{{- if .Values.user.externalTenant }}
+external tenant url: {{ include "external-tenant-host" . }}
+{{- end }}
 
 If this domain is not in your DNS records please add the a record in your
 hosts file to point this domain to any of your kubernetes worker nodes.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -333,6 +333,22 @@ Get "druid" database name
 {{- end -}}
 
 {{/*
+Get "analytics" database name
+*/}}
+{{- define "analytics-db-name" -}}
+    {{ if .Values.user.legacyDatabaseNames }}
+        {{- print "analytics" }}
+    {{- else }}
+        {{- $f:= .Values.user.kubeNamespace -}}
+        {{ if empty $f }}
+            {{- fail "Please define kubeNamespace in values.yaml" }}
+        {{- else }}
+            {{- printf "%s_%s" $f "analytics" | replace "-" "_" -}}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{/*
 Portal Docops page
 */}}
 {{- define "portal.help.page" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -336,9 +336,8 @@ Get "druid" database name
 Portal Docops page
 */}}
 {{- define "portal.help.page" -}}
-{{- printf "%s" "https://docops.ca.com/ca-api-developer-portal-enhanced-experience/4-3/en/" -}}
+{{- printf "%s" "https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/4-4.html" -}}
 {{- end -}}
-
 
 {{/*
 Generate a unique "default-tenant-id" appended with the kubeNamespace to enable multiple deployments on
@@ -431,6 +430,17 @@ Generate default tenant endpoint based on configurations
         {{- printf "%s.%s" .Values.user.defaultTenantId .Values.user.domain -}}
     {{- else }}
         {{- printf "%s-%s.%s" .Values.user.defaultTenantId .Values.user.kubeNamespace .Values.user.domain -}}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Generate external tenant endpoint based on configurations
+*/}}
+{{- define "external-tenant-host" -}}
+    {{- if .Values.user.legacyHostnames }}
+        {{- printf "%s.%s" .Values.user.externalTenant .Values.user.domain -}}
+    {{- else }}
+        {{- printf "%s-%s.%s" .Values.user.externalTenant .Values.user.kubeNamespace .Values.user.domain -}}
     {{- end }}
 {{- end -}}
 

--- a/templates/analytics-config.yaml
+++ b/templates/analytics-config.yaml
@@ -6,6 +6,7 @@ data:
   ANALYTICS_ENABLED: {{ .Values.user.analyticsEnabled | quote }}
   DATABASE_HOST: {{ required "Please fill in databaseHost in values.yaml" .Values.user.databaseHost | quote }}
   DATABASE_NAME: {{ include "portal-db-name" . | quote }}
+  ANALYTICS_DATABASE_NAME: {{ include "analytics-db-name" . | quote }}
   DATABASE_PASSWORD: {{ required "Please fill in databasePassword in values.yaml" .Values.user.databasePassword | quote }}
   DATABASE_PORT: {{ include "database-port" . | quote }}
   DATABASE_TYPE: {{ required "Please fill in databaseType in values.yaml" .Values.user.databaseType | quote }}

--- a/templates/authenticator-config.yaml
+++ b/templates/authenticator-config.yaml
@@ -11,7 +11,7 @@ data:
   JAVA_OPTIONS: -Xms1024m -Xmx1024m
   NSS_SDB_USE_CACHE: "no"
   PORTAL_VERSION: {{ .Chart.AppVersion }}
-  RABBITMQ_PASS: {{ .Values.rabbitmq.config.password | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.rabbitmq.config.password | quote }}
   RABBITMQ_PORT: {{ .Values.rabbitmq.config.port | quote }}
   RABBITMQ_USER: {{ .Values.rabbitmq.config.username | quote }}
 kind: ConfigMap

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -54,7 +54,7 @@ spec:
           serviceName: apim
           servicePort: {{ printf "%s-broker" .Values.user.defaultTenantId | quote }}
   {{- if .Values.user.externalTenant }}
-  - host: {{ printf "%s.%s" .Values.user.externalTenant .Values.user.domain | quote }}
+  - host: {{ include "external-tenant-host" . | quote }}
     http:
       paths:
       - backend:

--- a/templates/portaldb-config.yaml
+++ b/templates/portaldb-config.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 data:
   {{- if eq .Values.user.databaseType "postgresql" }}
   NSS_SDB_USE_CACHE: "no"
-  POSTGRES_DATABASES: "{{ include "ldds-db-name" . }},{{ include "portal-db-name" . }},{{ include "tps-db-name" . }},{{ include "rbac-db-name" . }},{{ include "otk-db-name" . }},{{ include "druid-db-name" . }},integration_core,integration_runscope"
+  POSTGRES_DATABASES: "{{ include "ldds-db-name" . }},{{ include "portal-db-name" . }},{{ include "tps-db-name" . }},{{ include "rbac-db-name" . }},{{ include "otk-db-name" . }},{{ include "druid-db-name" . }},integration_core,integration_runscope,{{ include "analytics-db-name" . }}"
   POSTGRES_PASSWORD: {{ required "Please fill in databasePassword in values.yaml" .Values.user.databasePassword | quote }}
   POSTGRES_REPLICATION_MODE: master
   POSTGRES_REPLICATION_PASSWORD: {{ required "Please fill in databasePassword in values.yaml" .Values.user.databasePassword | quote }}

--- a/templates/route.yml
+++ b/templates/route.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   host: {{ include "default-tenant-host" . | quote }}
   {{- if .Values.user.externalTenant }}
-  host: {{ printf "%s.%s" .Values.user.externalTenant .Values.user.domain | quote }}
+  host: {{ include "external-tenant-host" . | quote }}
   {{- end }}
   port:
     targetPort: portal-https

--- a/templates/tps-config.yaml
+++ b/templates/tps-config.yaml
@@ -19,7 +19,7 @@ data:
   PAPI_USERNAME: {{ .Values.user.papiUsername | quote }}
   PORTAL_VERSION: {{ .Chart.AppVersion }}
   PORTAL_DATABASE_NAME: {{ include "portal-db-name" . | quote }}
-  RABBITMQ_PASS: {{ .Values.rabbitmq.config.password | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.rabbitmq.config.password | quote }}
   RABBITMQ_PORT: {{ .Values.rabbitmq.config.port | quote }}
   RABBITMQ_USER: {{ .Values.rabbitmq.config.username | quote }}
   TPS_SSL_CERT: {{ include "tps-crt" . | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -166,28 +166,28 @@ image:
   pullSecrets: bintray
   postgres: postgres:latest
   mysql: portaldb:latest
-  smtp: smtp:4.4
-  rabbitmq: message-broker:4.4
-  dispatcher: dispatcher:4.4
-  pssg: pssg:4.4
-  apim: ingress:4.4
-  enterprise: portal-enterprise:4.4
-  data: portal-data:4.4
-  tps: tenant-provisioning-service:4.4
-  solr: solr:4.4
-  analytics: analytics-server:4.4
-  authenticator: authenticator:4.4
-  dbUpgrade: db-upgrade-portal:4.4
-  rbacUpgrade: db-upgrade-rbac:4.4
-  ingestion: ingestion-server:4.4
-  kafka: kafka:4.4
-  zookeeper: zookeeper:4.4
-  broker: druid:4.4
-  coordinator: druid:4.4
-  middlemanager: druid:4.4
-  minio: minio:4.4
-  historical: druid:4.4
-  upgradeVerify: upgrade-verify:4.4
+  smtp: smtp:4.5
+  rabbitmq: message-broker:4.5
+  dispatcher: dispatcher:4.5
+  pssg: pssg:4.5
+  apim: ingress:4.5
+  enterprise: portal-enterprise:4.5
+  data: portal-data:4.5
+  tps: tenant-provisioning-service:4.5
+  solr: solr:4.5
+  analytics: analytics-server:4.5
+  authenticator: authenticator:4.5
+  dbUpgrade: db-upgrade-portal:4.5
+  rbacUpgrade: db-upgrade-rbac:4.5
+  ingestion: ingestion-server:4.5
+  kafka: kafka:4.5
+  zookeeper: zookeeper:4.5
+  broker: druid:4.5
+  coordinator: druid:4.5
+  middlemanager: druid:4.5
+  minio: minio:4.5
+  historical: druid:4.5
+  upgradeVerify: upgrade-verify:4.5
   
 user:
   kubeNamespace: dev-portal
@@ -241,4 +241,4 @@ persistence:
     historical: 50Gi
     minio: 40Gi
     kafka: 10Gi
-    zookeeper: 2Gi
+    zookeeper: 10Gi


### PR DESCRIPTION
app changes:
- add analytics database schema
- updated image tags and doc references from 4.4 to 4.5

operational changes:
- remove creating external tenant in helm chart (adding external tenant is a manual operation outside of helm)
- change default papi port from 9443 to 443 (9443 was used for onprem swarm, changing to 443 for kube best practice - if upgrading from 4.4 or migrating from swarm, this is a breaking change for the papi url)
- increase default zookeeper volume size (volume requirement increase proportional to number of tenants)